### PR TITLE
Change name of data layer object.

### DIFF
--- a/src/EnhancedEcommerceService.js
+++ b/src/EnhancedEcommerceService.js
@@ -1,4 +1,4 @@
-//version = "V 1.1.0" Add UNRELEASED if the current version is not yet published to the CDN. When releasing remove UNRELEASED.
+//version = "V 1.2.0 UNRELEASED" Add UNRELEASED if the current version is not yet published to the CDN. When releasing remove UNRELEASED.
 
 class IndexDataSelector extends DataSelector {
     /**
@@ -75,6 +75,7 @@ class BoundEventListener {
 class EnhancedEcommerceService {
     constructor() {
         this.boundClickEventListeners = [];
+        this.dataLayerName = "dataLayer";
     }
 
     /**
@@ -199,10 +200,10 @@ class EnhancedEcommerceService {
      */
     privatePushToDataLayer(eventData) {
         // Create the data layer if it does not yet exists.
-        window.dataLayer = window.dataLayer || [];
+        window[this.dataLayerName] = window[this.dataLayerName] || [];
 
-        dataLayer.push(eventData);
-        console.log("Enhanced Ecommerce:", dataLayer[dataLayer.length - 1]);
+        window[this.dataLayerName].push(eventData);
+        console.log("Enhanced Ecommerce:", window[this.dataLayerName][window[this.dataLayerName].length - 1]);
     }
 
     /**


### PR DESCRIPTION
Allow the name of the data layer to be overwritten if the events needs to be pushed to another object than the default "dataLayer".

https://app.asana.com/0/1190053562273305/1202494131532892