### PR TITLE
Allow multiple buttons in a single element to be bound.

### DIFF
--- a/src/EnhancedEcommerceService.js
+++ b/src/EnhancedEcommerceService.js
@@ -131,7 +131,6 @@ class EnhancedEcommerceService {
     bindClickEcommerceEvent(eventName, dataSchema, initiatorSelector = "", defaultEcommerceSchema = true, stopPropagation = false) {
         const initiators = document.querySelectorAll(dataSchema.itemContainerSelector);
         initiators.forEach(initiator => {
-            const elementToBind = initiatorSelector === "" ? initiator : initiator.querySelector(initiatorSelector);
             let elementsToBind = [];
             initiatorSelector === "" ?  elementsToBind.push(initiator) : elementsToBind = initiator.querySelectorAll(initiatorSelector);
             elementsToBind.forEach(elementToBind => {
@@ -185,7 +184,7 @@ class EnhancedEcommerceService {
                     if(stopPropagation) {
                         event.stopPropagation();
                     }
-                    this._pushCustomEvent(eventName, dataSchema, initiator);
+                    this._pushCustomEvent(eventName, dataSchema, elementToBind);
                 }
                 elementToBind.addEventListener("click", eventListener);
                 this.boundClickEventListeners.push(new BoundEventListener(elementToBind, eventListener, "click"));

--- a/src/EnhancedEcommerceService.js
+++ b/src/EnhancedEcommerceService.js
@@ -132,18 +132,18 @@ class EnhancedEcommerceService {
         const initiators = document.querySelectorAll(dataSchema.itemContainerSelector);
         initiators.forEach(initiator => {
             const elementToBind = initiatorSelector === "" ? initiator : initiator.querySelector(initiatorSelector);
-            if(elementToBind == null) {
-                return;
-            }
-
-            const eventListener = (event) => {
-                if(stopPropagation) {
-                    event.stopPropagation();
+            let elementsToBind = [];
+            initiatorSelector === "" ?  elementsToBind.push(initiator) : elementsToBind = initiator.querySelectorAll(initiatorSelector);
+            elementsToBind.forEach(elementToBind => {
+                const eventListener = (event) => {
+                    if(stopPropagation) {
+                        event.stopPropagation();
+                    }
+                    this.privatePushEcommerceEvent(eventName, dataSchema, elementToBind, defaultEcommerceSchema);
                 }
-                this.privatePushEcommerceEvent(eventName, dataSchema, elementToBind, defaultEcommerceSchema);
-            }
-            elementToBind.addEventListener("click", eventListener);
-            this.boundClickEventListeners.push(new BoundEventListener(elementToBind, eventListener, "click"));
+                elementToBind.addEventListener("click", eventListener);
+                this.boundClickEventListeners.push(new BoundEventListener(elementToBind, eventListener, "click"));
+            });
         });
     }
 
@@ -178,19 +178,18 @@ class EnhancedEcommerceService {
     bindClickCustomEvent(eventName, dataSchema, initiatorSelector = "", stopPropagation = false) {
         const initiators = document.querySelectorAll(dataSchema.itemContainerSelector);
         initiators.forEach(initiator => {
-            const elementToBind = initiatorSelector === "" ? initiator : initiator.querySelector(initiatorSelector);
-            if(elementToBind == null) {
-                return;
-            }
-
-            const eventListener = (event) => {
-                if(stopPropagation) {
-                    event.stopPropagation();
+            let elementsToBind = [];
+            initiatorSelector === "" ?  elementsToBind.push(initiator) : elementsToBind = initiator.querySelectorAll(initiatorSelector);
+            elementsToBind.forEach(elementToBind => {
+                const eventListener = (event) => {
+                    if(stopPropagation) {
+                        event.stopPropagation();
+                    }
+                    this._pushCustomEvent(eventName, dataSchema, initiator);
                 }
-                this._pushCustomEvent(eventName, dataSchema, elementToBind);
-            }
-            elementToBind.addEventListener("click", eventListener);
-            this.boundClickEventListeners.push(new BoundEventListener(elementToBind, eventListener, "click"));
+                elementToBind.addEventListener("click", eventListener);
+                this.boundClickEventListeners.push(new BoundEventListener(elementToBind, eventListener, "click"));
+            });
         });
     }
 


### PR DESCRIPTION
When binding a click event it was assumed there was only 1 button to bind in each element found. This addition allows multiple buttons in a single event to be bound.

https://app.asana.com/0/1201027711166952/1203642868595957