### PR TITLE
Fix numeric values to be returned as a number

### DIFF
--- a/src/DataClasses.js
+++ b/src/DataClasses.js
@@ -86,7 +86,8 @@ class DataSelector {
             let matchedNumbers = data.match(/\d+\.\d+/);
             if(matchedNumbers != null) {
                 if(matchedNumbers.length === 1) {
-                    return matchedNumbers[0];
+                    // A match is always a number and can be safely cast.
+                    return Number(matchedNumbers[0]);
                 }
 
                 console.log(`The data selector '${this.name}', using selector '${this.selector}', had multiple decimal values converted to a number.`);
@@ -97,7 +98,8 @@ class DataSelector {
             matchedNumbers = data.match(/\d+/);
             if(matchedNumbers != null) {
                 if(matchedNumbers.length === 1) {
-                    return matchedNumbers[0];
+                    // A match is always a number and can be safely cast.
+                    return Number(matchedNumbers[0]);
                 }
 
                 console.log(`The data selector '${this.name}', using selector '${this.selector}', had multiple values converted to a number.`);


### PR DESCRIPTION
From a text the numeric value is retrieved but recently it still returned as text. It will now be parsed to a number to ensure its type.

https://app.asana.com/0/532235745247771/1204725299873212